### PR TITLE
build IRCMessage using bytes.Buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ _testmain.go
 *.test
 *.prof
 
+# vim swapfiles
+*.swp

--- a/.travis.gofmt.sh
+++ b/.travis.gofmt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SOURCES="."
+
+if [ -n "$(gofmt -s -l $SOURCES)" ]; then
+    echo "Go code is not formatted correctly with \`gofmt -s\`:"
+    gofmt -s -d $SOURCES
+    exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_install:
 script:
     - gotestcover -coverprofile=cover.out ./...
     - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile cover.out
+    - bash ./.travis.gofmt.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+test:
+	cd ircfmt && go test . && go vet .
+	cd ircmap && go test . && go vet .
+	cd ircmatch && go test . && go vet .
+	cd ircmsg && go test . && go vet .
+	cd ircutils && go test . && go vet .


### PR DESCRIPTION
Right now, we copy the message a lot of times:

1. Incrementally, to build it from immutable `string` objects
1. Into a `[]byte` so it can be sent
1. Into another string for logging (because we have to chop off the `\r\n`), whether or not the line will actually be logged

Anyway, if we build it using `bytes.Buffer`, then `buffer.Bytes()` gives us access to the same underlying array that was used for building. Total savings is up to 25% on some microbenchmarks (requiring accompanying changes to oragono).