### PR TITLE
Use string builders instead of string concatenation for ircfmt

### DIFF
--- a/ircfmt/ircfmt.go
+++ b/ircfmt/ircfmt.go
@@ -122,15 +122,16 @@ func Escape(in string) string {
 	in = valtoescape.Replace(in)
 
 	inRunes := []rune(in)
-	var out string
+	//var out string
+	out := strings.Builder{}
 	for 0 < len(inRunes) {
 		if 1 < len(inRunes) && inRunes[0] == '$' && inRunes[1] == 'c' {
 			// handle colours
-			out += "$c"
+			out.WriteString("$c")
 			inRunes = inRunes[2:] // strip colour code chars
 
 			if len(inRunes) < 1 || !strings.Contains(colours1, string(inRunes[0])) {
-				out += "[]"
+				out.WriteString("[]")
 				continue
 			}
 
@@ -159,19 +160,21 @@ func Escape(in string) string {
 				backName = backBuffer
 			}
 
-			out += "[" + foreName
+			out.WriteRune('[')
+			out.WriteString(foreName)
 			if backName != "" {
-				out += "," + backName
+				out.WriteRune(',')
+				out.WriteString(backName)
 			}
-			out += "]"
+			out.WriteRune(']')
 
 		} else {
-			out += string(inRunes[0])
+			out.WriteRune(inRunes[0])
 			inRunes = inRunes[1:]
 		}
 	}
 
-	return out
+	return out.String()
 }
 
 // Unescape takes our escaped string and returns a raw IRC string.
@@ -179,7 +182,7 @@ func Escape(in string) string {
 // IE, it turns this: "This is a $bcool$b, $c[red]red$r message!"
 // into this: "This is a \x02cool\x02, \x034red\x0f message!"
 func Unescape(in string) string {
-	out := ""
+	out := strings.Builder{}
 
 	remaining := []rune(in)
 	for 0 < len(remaining) {
@@ -192,9 +195,9 @@ func Unescape(in string) string {
 
 			val, exists := escapetoval[char]
 			if exists {
-				out += val
+				out.WriteString(val)
 			} else if char == 'c' {
-				out += colour
+				out.WriteString(colour)
 
 				if len(remaining) < 2 || remaining[0] != '[' {
 					continue
@@ -244,18 +247,19 @@ func Unescape(in string) string {
 				}
 
 				// output colour codes
-				out += foreColour
+				out.WriteString(foreColour)
 				if backColour != "" {
-					out += "," + backColour
+					out.WriteRune(',')
+					out.WriteString(backColour)
 				}
 			} else {
 				// unknown char
-				out += string(char)
+				out.WriteRune(char)
 			}
 		} else {
-			out += string(char)
+			out.WriteRune(char)
 		}
 	}
 
-	return out
+	return out.String()
 }


### PR DESCRIPTION
String concatenation requires the recreation of string objects and is in general slower than a string builder. This PR replaces all the concatenation in the ircfmt package with string builders.