### PR TITLE
Add strip function to IRCfmt

### DIFF
--- a/ircfmt/ircfmt.go
+++ b/ircfmt/ircfmt.go
@@ -122,15 +122,16 @@ func Escape(in string) string {
 	in = valtoescape.Replace(in)
 
 	inRunes := []rune(in)
-	var out string
+	//var out string
+	out := strings.Builder{}
 	for 0 < len(inRunes) {
 		if 1 < len(inRunes) && inRunes[0] == '$' && inRunes[1] == 'c' {
 			// handle colours
-			out += "$c"
+			out.WriteString("$c")
 			inRunes = inRunes[2:] // strip colour code chars
 
 			if len(inRunes) < 1 || !strings.Contains(colours1, string(inRunes[0])) {
-				out += "[]"
+				out.WriteString("[]")
 				continue
 			}
 
@@ -159,19 +160,21 @@ func Escape(in string) string {
 				backName = backBuffer
 			}
 
-			out += "[" + foreName
+			out.WriteRune('[')
+			out.WriteString(foreName)
 			if backName != "" {
-				out += "," + backName
+				out.WriteRune(',')
+				out.WriteString(backName)
 			}
-			out += "]"
+			out.WriteRune(']')
 
 		} else {
-			out += string(inRunes[0])
+			out.WriteRune(inRunes[0])
 			inRunes = inRunes[1:]
 		}
 	}
 
-	return out
+	return out.String()
 }
 
 // Unescape takes our escaped string and returns a raw IRC string.
@@ -179,7 +182,7 @@ func Escape(in string) string {
 // IE, it turns this: "This is a $bcool$b, $c[red]red$r message!"
 // into this: "This is a \x02cool\x02, \x034red\x0f message!"
 func Unescape(in string) string {
-	out := ""
+	out := strings.Builder{}
 
 	remaining := []rune(in)
 	for 0 < len(remaining) {
@@ -192,9 +195,9 @@ func Unescape(in string) string {
 
 			val, exists := escapetoval[char]
 			if exists {
-				out += val
+				out.WriteString(val)
 			} else if char == 'c' {
-				out += colour
+				out.WriteString(colour)
 
 				if len(remaining) < 2 || remaining[0] != '[' {
 					continue
@@ -244,18 +247,19 @@ func Unescape(in string) string {
 				}
 
 				// output colour codes
-				out += foreColour
+				out.WriteString(foreColour)
 				if backColour != "" {
-					out += "," + backColour
+					out.WriteRune(',')
+					out.WriteString(backColour)
 				}
 			} else {
 				// unknown char
-				out += string(char)
+				out.WriteRune(char)
 			}
 		} else {
-			out += string(char)
+			out.WriteRune(char)
 		}
 	}
 
-	return out
+	return out.String()
 }

--- a/ircfmt/ircfmt.go
+++ b/ircfmt/ircfmt.go
@@ -27,6 +27,8 @@ const (
 var (
 	// valtoescape replaces most of IRC characters with our escapes.
 	valtoescape = strings.NewReplacer("$", "$$", colour, "$c", reverseColour, "$v", bold, "$b", italic, "$i", strikethrough, "$s", underline, "$u", monospace, "$m", reset, "$r")
+	// valToStrip replaces most of the IRC characters with nothing
+	valToStrip = strings.NewReplacer(colour, "$c", reverseColour, "", bold, "", italic, "", strikethrough, "", underline, "", monospace, "", reset, "")
 
 	// escapetoval contains most of our escapes and how they map to real IRC characters.
 	// intentionally skips colour, since that's handled elsewhere.
@@ -167,6 +169,43 @@ func Escape(in string) string {
 				out.WriteString(backName)
 			}
 			out.WriteRune(']')
+
+		} else {
+			out.WriteRune(inRunes[0])
+			inRunes = inRunes[1:]
+		}
+	}
+
+	return out.String()
+}
+
+// Strip takes a raw IRC string and removes it with all formatting codes removed
+// IE, it turns this: "This is a \x02cool\x02, \x034red\x0f message!"
+// into: "This is a cool, red message!"
+func Strip(in string) string {
+	// replace all our usual escapes
+	in = valToStrip.Replace(in)
+
+	inRunes := []rune(in)
+	out := strings.Builder{}
+	for 0 < len(inRunes) {
+		if 1 < len(inRunes) && inRunes[0] == '$' && inRunes[1] == 'c' {
+			inRunes = inRunes[2:] // strip colour code chars
+
+			if len(inRunes) < 1 || !strings.ContainsRune(colours1, inRunes[0]) {
+				continue
+			}
+
+			inRunes = inRunes[1:]
+			if 0 < len(inRunes) && strings.ContainsRune(colours1, inRunes[0]) {
+				inRunes = inRunes[1:]
+			}
+			if 1 < len(inRunes) && inRunes[0] == ',' && strings.ContainsRune(colours1, inRunes[1]) {
+				inRunes = inRunes[2:]
+				if 0 < len(inRunes) && strings.ContainsRune(colours1, inRunes[0]) {
+					inRunes = inRunes[1:]
+				}
+			}
 
 		} else {
 			out.WriteRune(inRunes[0])

--- a/ircfmt/ircfmt_test.go
+++ b/ircfmt/ircfmt_test.go
@@ -27,6 +27,15 @@ var unescapetests = []testcase{
 	{"test$c", "test\x03"},
 }
 
+var stripTests = []testcase {
+	{"te\x02st", "test"},
+	{"te\x033st", "test"},
+	{"te\x034,3st", "test"},
+	{"te\x03034st", "te4st"},
+	{"te\x034,039st", "te9st"},
+	{" ▀█▄▀▪.▀  ▀ ▀  ▀ ·▀▀▀▀  ▀█▄▀ ▀▀ █▪ ▀█▄▀▪", " ▀█▄▀▪.▀  ▀ ▀  ▀ ·▀▀▀▀  ▀█▄▀ ▀▀ █▪ ▀█▄▀▪"},
+}
+
 func TestEscape(t *testing.T) {
 	for _, pair := range tests {
 		val := Escape(pair.unescaped)
@@ -73,6 +82,19 @@ func TestUnescape(t *testing.T) {
 				"expected", pair.unescaped,
 				"got", val,
 			)
+		}
+	}
+}
+
+func TestStrip(t *testing.T) {
+	for _, pair := range stripTests {
+		val := Strip(pair.escaped)
+		if val != pair.unescaped {
+			t.Error(
+				"For", pair.escaped,
+				"expected", pair.unescaped,
+				"got", val,
+				)
 		}
 	}
 }


### PR DESCRIPTION
This adds a strip function to ircfmt that removes all IRC formatting from the line.

This PR appears to contain more than that but this is due to it being dependent on #9 