### PR TITLE
fix $c being incorrectly escaped

### DIFF
--- a/ircfmt/ircfmt.go
+++ b/ircfmt/ircfmt.go
@@ -175,7 +175,7 @@ func Escape(in string) string {
 			if len(inRunes) > 2 && inRunes[0] == '$' && inRunes[1] == '$' && inRunes[2] == 'c' {
 				out.WriteRune(inRunes[0])
 				out.WriteRune(inRunes[1])
-                out.WriteRune(inRunes[2])
+				out.WriteRune(inRunes[2])
 				inRunes = inRunes[3:]
 			} else {
 				out.WriteRune(inRunes[0])

--- a/ircfmt/ircfmt.go
+++ b/ircfmt/ircfmt.go
@@ -171,8 +171,16 @@ func Escape(in string) string {
 			out.WriteRune(']')
 
 		} else {
-			out.WriteRune(inRunes[0])
-			inRunes = inRunes[1:]
+			// special case for $$c
+			if len(inRunes) > 2 && inRunes[0] == '$' && inRunes[1] == '$' && inRunes[2] == 'c' {
+				out.WriteRune(inRunes[0])
+				out.WriteRune(inRunes[1])
+                out.WriteRune(inRunes[2])
+				inRunes = inRunes[3:]
+			} else {
+				out.WriteRune(inRunes[0])
+				inRunes = inRunes[1:]
+			}
 		}
 	}
 

--- a/ircfmt/ircfmt_test.go
+++ b/ircfmt/ircfmt_test.go
@@ -14,6 +14,9 @@ var tests = []testcase{
 	{"te$c[green]4st", "te\x03034st"},
 	{"te$c[red,green]9st", "te\x034,039st"},
 	{" ▀█▄▀▪.▀  ▀ ▀  ▀ ·▀▀▀▀  ▀█▄▀ ▀▀ █▪ ▀█▄▀▪", " ▀█▄▀▪.▀  ▀ ▀  ▀ ·▀▀▀▀  ▀█▄▀ ▀▀ █▪ ▀█▄▀▪"},
+	{"test $$c", "test $c"},
+	{"test $c[]", "test \x03"},
+	{"test $$", "test $"},
 }
 
 var escapetests = []testcase{
@@ -57,6 +60,16 @@ func TestEscape(t *testing.T) {
 				"expected", pair.escaped,
 				"got", val,
 			)
+		}
+	}
+}
+
+func TestChain(t *testing.T) {
+	for _, pair := range tests {
+		escaped := Escape(pair.unescaped)
+		unescaped := Unescape(escaped)
+		if unescaped != pair.unescaped {
+			t.Errorf("for %q expected %q got %q", pair.unescaped, pair.unescaped, unescaped)
 		}
 	}
 }


### PR DESCRIPTION
when escaping a string such as `test $c`, it is incorrectly escaped to `test $c[]`, which, if unescaped, becomes `test \x03`. This PR fixes this issue, and adds an additional test to confirm that the escaping is stable when chained.