### PR TITLE
Update the Example IRC-Go Client to Function with the New Tag Handling System

### DIFF
--- a/client/actions.go
+++ b/client/actions.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Msg sends a message to the given target.
-func (sc *ServerConnection) Msg(tags *map[string]string, target string, message string, escaped bool) {
+func (sc *ServerConnection) Msg(tags map[string]string, target string, message string, escaped bool) {
 	if escaped {
 		message = ircfmt.Unescape(message)
 	}
@@ -16,7 +16,7 @@ func (sc *ServerConnection) Msg(tags *map[string]string, target string, message 
 }
 
 // Notice sends a notice to the given target.
-func (sc *ServerConnection) Notice(tags *map[string]string, target string, message string, escaped bool) {
+func (sc *ServerConnection) Notice(tags map[string]string, target string, message string, escaped bool) {
 	if escaped {
 		message = ircfmt.Unescape(message)
 	}

--- a/client/actions.go
+++ b/client/actions.go
@@ -5,11 +5,10 @@ package gircclient
 
 import (
 	"github.com/goshuirc/irc-go/ircfmt"
-	"github.com/goshuirc/irc-go/ircmsg"
 )
 
 // Msg sends a message to the given target.
-func (sc *ServerConnection) Msg(tags *map[string]ircmsg.TagValue, target string, message string, escaped bool) {
+func (sc *ServerConnection) Msg(tags *map[string]string, target string, message string, escaped bool) {
 	if escaped {
 		message = ircfmt.Unescape(message)
 	}
@@ -17,7 +16,7 @@ func (sc *ServerConnection) Msg(tags *map[string]ircmsg.TagValue, target string,
 }
 
 // Notice sends a notice to the given target.
-func (sc *ServerConnection) Notice(tags *map[string]ircmsg.TagValue, target string, message string, escaped bool) {
+func (sc *ServerConnection) Notice(tags *map[string]string, target string, message string, escaped bool) {
 	if escaped {
 		message = ircfmt.Unescape(message)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -236,7 +236,7 @@ func (sc *ServerConnection) Casefold(message string) (string, error) {
 
 // Send sends an IRC message to the server. If the message cannot be converted
 // to a raw IRC line, an error is returned.
-func (sc *ServerConnection) Send(tags *map[string]ircmsg.TagValue, prefix string, command string, params ...string) error {
+func (sc *ServerConnection) Send(tags *map[string]string, prefix string, command string, params ...string) error {
 	msg := ircmsg.MakeMessage(tags, prefix, command, params...)
 	line, err := msg.Line()
 	if err != nil {
@@ -251,7 +251,7 @@ func (sc *ServerConnection) Send(tags *map[string]ircmsg.TagValue, prefix string
 	info["data"] = line
 	sc.dispatchRawOut(info)
 
-	var outTags map[string]ircmsg.TagValue
+	var outTags map[string]string
 	if tags == nil {
 		outTags = *ircmsg.MakeTags()
 	} else {

--- a/client/client.go
+++ b/client/client.go
@@ -156,7 +156,7 @@ func (sc *ServerConnection) ProcessIncomingLine(line string) {
 	info := eventmgr.NewInfoMap()
 	info["server"] = sc
 	info["direction"] = "in"
-	info["tags"] = message.Tags
+	info["tags"] = message.AllTags()
 	info["prefix"] = message.Prefix
 	info["command"] = cmd
 	info["params"] = message.Params
@@ -236,7 +236,7 @@ func (sc *ServerConnection) Casefold(message string) (string, error) {
 
 // Send sends an IRC message to the server. If the message cannot be converted
 // to a raw IRC line, an error is returned.
-func (sc *ServerConnection) Send(tags *map[string]string, prefix string, command string, params ...string) error {
+func (sc *ServerConnection) Send(tags map[string]string, prefix string, command string, params ...string) error {
 	msg := ircmsg.MakeMessage(tags, prefix, command, params...)
 	line, err := msg.Line()
 	if err != nil {
@@ -253,9 +253,9 @@ func (sc *ServerConnection) Send(tags *map[string]string, prefix string, command
 
 	var outTags map[string]string
 	if tags == nil {
-		outTags = *ircmsg.MakeTags()
+		outTags = map[string]string{}
 	} else {
-		outTags = *tags
+		outTags = tags
 	}
 
 	// dispatch real event

--- a/client/reactor_test.go
+++ b/client/reactor_test.go
@@ -122,7 +122,7 @@ func TestTLSConnection(t *testing.T) {
 	testServerConnection(t, reactor, client, listener)
 }
 
-func sendMessage(conn net.Conn, tags *map[string]ircmsg.TagValue, prefix string, command string, params ...string) {
+func sendMessage(conn net.Conn, tags map[string]string, prefix string, command string, params ...string) {
 	ircmsg := ircmsg.MakeMessage(tags, prefix, command, params...)
 	line, err := ircmsg.Line()
 	if err != nil {


### PR DESCRIPTION
As the title implies this fixes the broken example client that comes with the library. Now I'm not 100% sure if tags work fully however in my limited testing everything appears in order.
Cheers.