### PR TITLE
Basic Command Handler

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -178,9 +178,9 @@ func (sc *ServerConnection) ProcessIncomingLine(line string) {
 
 	// IRC commands are case-insensitive
 	sc.dispatchIn(strings.ToUpper(cmd), info)
-        if strings.ToUpper(cmd) == "PRIVMSG" {
-            sc.dispatchBasicCmd(info)
-        }
+	if strings.ToUpper(cmd) == "PRIVMSG" {
+		sc.dispatchBasicCmd(info)
+	}
 
 }
 
@@ -281,14 +281,14 @@ func (sc *ServerConnection) Send(tags map[string]string, prefix string, command 
 
 // dispatchCommand dispatches an event based on simple commands (e.g !help)
 func (sc *ServerConnection) dispatchBasicCmd(info eventmgr.InfoMap) {
-    cmd := info["params"].([]string)
-    pfx := cmd[1][0]
+	cmd := info["params"].([]string)
+	pfx := cmd[1][0]
 
-    for _, p := range basicCmdPrefixes {
-        if pfx == p {
-            sc.eventsIn.Dispatch("cmd"+cmd[1], info)
-        }
-    }
+	for _, p := range basicCmdPrefixes {
+		if pfx == p {
+			sc.eventsIn.Dispatch("cmd"+cmd[1], info)
+		}
+	}
 }
 
 // dispatchRawIn dispatches raw inbound messages.

--- a/client/client.go
+++ b/client/client.go
@@ -179,7 +179,7 @@ func (sc *ServerConnection) ProcessIncomingLine(line string) {
 	// IRC commands are case-insensitive
 	sc.dispatchIn(strings.ToUpper(cmd), info)
 	if strings.ToUpper(cmd) == "PRIVMSG" {
-		sc.dispatchBasicCmd(info)
+		sc.dispatchCommand(info)
 	}
 
 }
@@ -285,14 +285,15 @@ func (sc *ServerConnection) Send(tags map[string]string, prefix string, command 
 }
 
 // dispatchCommand dispatches an event based on simple commands (e.g !help)
-func (sc *ServerConnection) dispatchBasicCmd(info eventmgr.InfoMap) {
-	cmd := strings.Split(info["params"].([]string)[1], " ")[0]
-	pfx := cmd[0]
+func (sc *ServerConnection) dispatchCommand(info eventmgr.InfoMap) {
+	params := strings.Split(info["params"].([]string)[1], " ")
 
 	for _, p := range basicCmdPrefixes {
-		if pfx == p {
-			sc.eventsIn.Dispatch("cmd"+cmd, info)
-		}
+		if strings.HasPrefix(params[0], string(p)) {
+            sc.eventsIn.Dispatch("cmd_"+params[0][1:], info)
+        } else if (params[0] == sc.Nick || params[0] == sc.Nick + ":") && len(params) > 1 {
+            sc.eventsIn.Dispatch("cmd_"+params[1], info)
+        }
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -20,11 +20,11 @@ import (
 
 // ServerConnection is a connection to a single server.
 type ServerConnection struct {
-	Name        string
-	Connected   bool
-	Registered  bool
-	Casemapping ircmap.MappingType
-    CommandPrefixes []string
+	Name            string
+	Connected       bool
+	Registered      bool
+	Casemapping     ircmap.MappingType
+	CommandPrefixes []string
 
 	// internal stuff
 	RawConnection  net.Conn
@@ -229,7 +229,7 @@ func (sc *ServerConnection) RegisterEvent(direction string, name string, handler
 
 // RegisterCommand registers a command to be called via the configured prefix or the client's nickname (e.g !help, "GoshuBot: help")
 func (sc *ServerConnection) RegisterCommand(name string, handler eventmgr.HandlerFn, priority int) {
-    sc.eventsIn.Attach("cmd_"+name, handler, priority)
+	sc.eventsIn.Attach("cmd_"+name, handler, priority)
 }
 
 // Shutdown closes the connection to the server.
@@ -289,14 +289,14 @@ func (sc *ServerConnection) dispatchCommand(info eventmgr.InfoMap) {
 
 	for _, p := range sc.CommandPrefixes {
 		if strings.HasPrefix(params[0], p) {
-            sc.eventsIn.Dispatch("cmd_"+params[0][1:], info)
-            return
-        }
+			sc.eventsIn.Dispatch("cmd_"+params[0][1:], info)
+			return
+		}
 	}
 
-    if (params[0] == sc.Nick || params[0] == sc.Nick + ":") && len(params) > 1 {
-        sc.eventsIn.Dispatch("cmd_"+params[1], info)
-    }
+	if (params[0] == sc.Nick || params[0] == sc.Nick+":") && len(params) > 1 {
+		sc.eventsIn.Dispatch("cmd_"+params[1], info)
+	}
 }
 
 // dispatchRawIn dispatches raw inbound messages.

--- a/client/client.go
+++ b/client/client.go
@@ -228,6 +228,11 @@ func (sc *ServerConnection) RegisterEvent(direction string, name string, handler
 	}
 }
 
+// RegisterCommand registers a command to be called via the configured prefix or the client's nickname (e.g !help, "GoshuBot: help")
+func (sc *ServerConnection) RegisterCommand(name string, handler eventmgr.HandlerFn, priority int) {
+    sc.eventsIn.Attach("cmd_"+name, handler, priority)
+}
+
 // Shutdown closes the connection to the server.
 func (sc *ServerConnection) Shutdown(message string) {
 	sc.Send(nil, "", "QUIT", message)

--- a/client/client.go
+++ b/client/client.go
@@ -285,7 +285,7 @@ func (sc *ServerConnection) Send(tags map[string]string, prefix string, command 
 
 // dispatchCommand dispatches an event based on simple commands (e.g !help)
 func (sc *ServerConnection) dispatchCommand(info eventmgr.InfoMap) {
-	params := strings.Split(info["params"].([]string)[1], " ")
+	params := strings.Fields(info["params"].([]string)[1])
 
 	for _, p := range sc.CommandPrefixes {
 		if strings.HasPrefix(params[0], p) {

--- a/client/client.go
+++ b/client/client.go
@@ -281,12 +281,12 @@ func (sc *ServerConnection) Send(tags map[string]string, prefix string, command 
 
 // dispatchCommand dispatches an event based on simple commands (e.g !help)
 func (sc *ServerConnection) dispatchBasicCmd(info eventmgr.InfoMap) {
-	cmd := info["params"].([]string)
-	pfx := cmd[1][0]
+	cmd := strings.Split(info["params"].([]string)[1], " ")[0]
+	pfx := cmd[0]
 
 	for _, p := range basicCmdPrefixes {
 		if pfx == p {
-			sc.eventsIn.Dispatch("cmd"+cmd[1], info)
+			sc.eventsIn.Dispatch("cmd"+cmd, info)
 		}
 	}
 }


### PR DESCRIPTION
This adds a basic command handler to the example client. To use this, register an event starting with `cmd` followed by the prefix (`!`, `@`, `$`, `~`, `.`) and the command trigger word.

As an example on how it's used:
`server.RegisterEvent("in", "cmd!quit", quitHandler, 0)` would execute `quitHandler` when it receives a PRIVMSG containing `!quit`