### PR TITLE
Correct incorrect usage of fmt.Fprintf

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -242,7 +242,7 @@ func (sc *ServerConnection) Send(tags map[string]string, prefix string, command 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(sc.RawConnection, line)
+	fmt.Fprint(sc.RawConnection, line)
 
 	// dispatch raw event
 	info := eventmgr.NewInfoMap()


### PR DESCRIPTION
>%!E(MISSING). %!E(MISSING) everywhere.

Fprintf spews out garbarge when you throw in a percent sign with no formatters specificed. This fixes that problem.