### PR TITLE
switch to modules, add ForceTrailing to ircmsg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ test:
 	cd ircmatch && go test . && go vet .
 	cd ircmsg && go test . && go vet .
 	cd ircutils && go test . && go vet .
-	./.check_gofmt.sh
+	./.check-gofmt.sh

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/goshuirc/irc-go
+
+go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/goshuirc/irc-go
 
 go 1.14
+
+require (
+	github.com/DanielOaks/go-idn v0.0.0-20160120021903-76db0e10dc65
+	github.com/goshuirc/e-nfa v0.0.0-20160917075329-7071788e3940
+	golang.org/x/text v0.3.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/DanielOaks/go-idn v0.0.0-20160120021903-76db0e10dc65 h1:DXLz23jPaNHJ0okNtScVpSVa87hwQHstIgnMUkaVIck=
+github.com/DanielOaks/go-idn v0.0.0-20160120021903-76db0e10dc65/go.mod h1:GYIaL2hleNQvfMUBTes1Zd/lDTyI/p2hv3kYB4jssyU=
+github.com/goshuirc/e-nfa v0.0.0-20160917075329-7071788e3940 h1:KmRLPRstEJiE/9OjumKqI8Rccip8Qmyw2FwyTFxtVqs=
+github.com/goshuirc/e-nfa v0.0.0-20160917075329-7071788e3940/go.mod h1:VOmrX6cmj7zwUeexC9HzznUdTIObHqIXUrWNYS+Ik7w=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/ircmsg/message.go
+++ b/ircmsg/message.go
@@ -382,9 +382,9 @@ func (ircmsg *IrcMessage) line(tagLimit, clientOnlyTagDataLimit, serverAddedTagD
 	for i, param := range ircmsg.Params {
 		buf.WriteByte(' ')
 		requiresTrailing := paramRequiresTrailing(param)
-		if (requiresTrailing || ircmsg.ForceTrailing) && i == len(ircmsg.Params) - 1 {
+		if (requiresTrailing || ircmsg.ForceTrailing) && i == len(ircmsg.Params)-1 {
 			buf.WriteByte(':')
-		} else if requiresTrailing && i != len(ircmsg.Params) - 1 {
+		} else if requiresTrailing && i != len(ircmsg.Params)-1 {
 			return nil, ErrorBadParam
 		}
 		buf.WriteString(param)

--- a/ircmsg/message.go
+++ b/ircmsg/message.go
@@ -58,8 +58,9 @@ type IrcMessage struct {
 }
 
 // ForceTrailing ensures that when the message is serialized, the final parameter
-// will be encoded as a "trailing parameter", i.e., preceded by a colon. This is
-// necessary for compatibility with incorrect implementations.
+// will be encoded as a "trailing parameter" (preceded by a colon). This is
+// almost never necessary and should not be used except when having to interact
+// with broken implementations that don't correctly interpret IRC messages.
 func (msg *IrcMessage) ForceTrailing() {
 	msg.forceTrailing = true
 }

--- a/ircmsg/message_test.go
+++ b/ircmsg/message_test.go
@@ -316,6 +316,29 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
+func TestForceTrailing(t *testing.T) {
+	message := IrcMessage {
+		Prefix: "shivaram",
+		Command: "PRIVMSG",
+		Params: []string{"#darwin", "nice"},
+	}
+	bytes, err := message.LineBytesStrict(true, 0)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(bytes) != ":shivaram PRIVMSG #darwin nice\r\n" {
+		t.Errorf("unexpected serialization: %s", bytes)
+	}
+	message.ForceTrailing = true
+	bytes, err = message.LineBytesStrict(true, 0)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(bytes) != ":shivaram PRIVMSG #darwin :nice\r\n" {
+		t.Errorf("unexpected serialization: %s", bytes)
+	}
+}
+
 func TestErrorLineTooLongGeneration(t *testing.T) {
 	message := IrcMessage{
 		tags:    map[string]string{"draft/msgid": "SAXV5OYJUr18CNJzdWa1qQ"},

--- a/ircmsg/message_test.go
+++ b/ircmsg/message_test.go
@@ -317,10 +317,10 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestForceTrailing(t *testing.T) {
-	message := IrcMessage {
-		Prefix: "shivaram",
+	message := IrcMessage{
+		Prefix:  "shivaram",
 		Command: "PRIVMSG",
-		Params: []string{"#darwin", "nice"},
+		Params:  []string{"#darwin", "nice"},
 	}
 	bytes, err := message.LineBytesStrict(true, 0)
 	if err != nil {

--- a/ircmsg/message_test.go
+++ b/ircmsg/message_test.go
@@ -329,7 +329,7 @@ func TestForceTrailing(t *testing.T) {
 	if string(bytes) != ":shivaram PRIVMSG #darwin nice\r\n" {
 		t.Errorf("unexpected serialization: %s", bytes)
 	}
-	message.ForceTrailing = true
+	message.ForceTrailing()
 	bytes, err = message.LineBytesStrict(true, 0)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
The rationale is that we're never going to be rid of forced trailing parameters, they're too entrenched. So using this library in practice is always going to require some kind of workaround, and it's much cleaner to provide it here than to do the thing Oragono currently does.