### PR TITLE
use strings.Builder for tag unescaping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 script:
     - gotestcover -coverprofile=cover.out ./...
     - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile cover.out
-    - bash ./.travis.gofmt.sh
+    - make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 test:
 	cd ircfmt && go test . && go vet .
 	cd ircmap && go test . && go vet .
-	cd ircmatch && go test . && go vet .
 	cd ircmsg && go test . && go vet .
 	cd ircutils && go test . && go vet .
 	./.check-gofmt.sh

--- a/ircmsg/tags.go
+++ b/ircmsg/tags.go
@@ -3,7 +3,6 @@
 
 package ircmsg
 
-import "bytes"
 import "strings"
 
 var (
@@ -39,7 +38,7 @@ func EscapeTagValue(inString string) string {
 // so you don't need to call it yourself after parsing a line.
 func UnescapeTagValue(inString string) string {
 	// buf.Len() == 0 is the fastpath where we have not needed to unescape any chars
-	var buf bytes.Buffer
+	var buf strings.Builder
 	remainder := inString
 	for {
 		backslashPos := strings.IndexByte(remainder, '\\')

--- a/ircmsg/tags_test.go
+++ b/ircmsg/tags_test.go
@@ -92,14 +92,14 @@ var tagdecodetests = []testtags{
 	{"time=12732;re=;asdf=5678", map[string]string{"time": "12732", "re": "", "asdf": "5678"}},
 	{"time=12732;draft/label=b;re=;asdf=5678", map[string]string{"time": "12732", "re": "", "asdf": "5678", "draft/label": "b"}},
 	{"=these;time=12732;=shouldbe;re=;asdf=5678;=ignored", map[string]string{"time": "12732", "re": "", "asdf": "5678"}},
-	{"dolphin=🐬;time=123456", map[string]string{"dolphin": "🐬", "time": "123456",}},
-	{"+dolphin=🐬;+draft/fox=f🦊x", map[string]string{"+dolphin": "🐬", "+draft/fox": "f🦊x",}},
-	{"+dolphin=🐬;+draft/f🦊x=fox", map[string]string{"+dolphin": "🐬",}},
-	{"+dolphin=🐬;+f🦊x=fox", map[string]string{"+dolphin": "🐬",}},
-	{"+dolphin=🐬;f🦊x=fox", map[string]string{"+dolphin": "🐬",}},
-	{"dolphin=🐬;f🦊x=fox", map[string]string{"dolphin": "🐬",}},
-	{"f🦊x=fox;+oragono.io/dolphin=🐬", map[string]string{"+oragono.io/dolphin": "🐬",}},
-	{"a=b;\\/=.", map[string]string{"a": "b",}},
+	{"dolphin=🐬;time=123456", map[string]string{"dolphin": "🐬", "time": "123456"}},
+	{"+dolphin=🐬;+draft/fox=f🦊x", map[string]string{"+dolphin": "🐬", "+draft/fox": "f🦊x"}},
+	{"+dolphin=🐬;+draft/f🦊x=fox", map[string]string{"+dolphin": "🐬"}},
+	{"+dolphin=🐬;+f🦊x=fox", map[string]string{"+dolphin": "🐬"}},
+	{"+dolphin=🐬;f🦊x=fox", map[string]string{"+dolphin": "🐬"}},
+	{"dolphin=🐬;f🦊x=fox", map[string]string{"dolphin": "🐬"}},
+	{"f🦊x=fox;+oragono.io/dolphin=🐬", map[string]string{"+oragono.io/dolphin": "🐬"}},
+	{"a=b;\\/=.", map[string]string{"a": "b"}},
 }
 
 func parseTags(rawTags string) (map[string]string, error) {


### PR DESCRIPTION
Not a huge deal. Speeds up the slowpath where we actually have to process escapes by a tiny amount.